### PR TITLE
Make emoji fetcher action macOS sierra compatible

### DIFF
--- a/fastlane-plugin-emoji_fetcher/lib/fastlane/plugin/emoji_fetcher/actions/emoji_fetcher_action.rb
+++ b/fastlane-plugin-emoji_fetcher/lib/fastlane/plugin/emoji_fetcher/actions/emoji_fetcher_action.rb
@@ -4,7 +4,7 @@ module Fastlane
       def self.run(params)
         require 'fileutils'
 
-        original = "/System/Library/Fonts/Apple Color Emoji.ttf"
+        original = "/System/Library/Fonts/Apple Color Emoji.ttc"
         UI.user_error!("Could not find font file at path '#{original}'") unless File.exist?(original)
         FileUtils.cp(original, params[:path])
         UI.success("Successfully fetched Emoji font")

--- a/fastlane-plugin-emoji_fetcher/lib/fastlane/plugin/emoji_fetcher/actions/emoji_fetcher_action.rb
+++ b/fastlane-plugin-emoji_fetcher/lib/fastlane/plugin/emoji_fetcher/actions/emoji_fetcher_action.rb
@@ -4,9 +4,10 @@ module Fastlane
       def self.run(params)
         require 'fileutils'
 
-        original = "/System/Library/Fonts/Apple Color Emoji.ttc"
-        UI.user_error!("Could not find font file at path '#{original}'") unless File.exist?(original)
-        FileUtils.cp(original, params[:path])
+        paths = ["/System/Library/Fonts/Apple Color Emoji.ttc", "/System/Library/Fonts/Apple Color Emoji.ttf"]
+        paths = paths.delete_if? { |a| !File.exist?(a) }
+        UI.user_error!("Could not find Emoji font.") if paths.count == 0
+        FileUtils.cp(paths.first, params[:path])
         UI.success("Successfully fetched Emoji font")
       end
 


### PR DESCRIPTION
The emoji font changed to ttc-format since macOS Sierra.
Closes [issue 1](https://github.com/Themoji/all/issues/1)